### PR TITLE
Update browserify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/chromiumify/chromiumify",
   "dependencies": {
-    "browserify": "^10.2.4",
+    "browserify": "^13.0.1",
     "launch-chrome-app": "^1.0.1",
     "shelljs": "^0.5.1",
     "yargs": "^3.14.0"


### PR DESCRIPTION
outdated browserify imports the wrong version of readable-stream and causes an error.

https://github.com/feross/chrome-net/issues/27
